### PR TITLE
修改第三方登录BUG

### DIFF
--- a/app/Http/Controllers/Auth/OAuthController.php
+++ b/app/Http/Controllers/Auth/OAuthController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Auth;
 
 use Auth;
+use Cache;
+use App\Models\Config;
 use App\Models\OauthUser;
 use Socialite;
 use Illuminate\Http\Request;
@@ -19,6 +21,31 @@ class OAuthController extends Controller
      */
     public function redirectToProvider(Request $request, $service)
     {
+        $config = Cache::remember('config', 10080, function () {
+            return Config::pluck('value','name');
+        });
+        switch ($service)
+        {
+            case 'qq':
+                $serviceConfig = [
+                    'services.qq.client_id' => $config['QQ_APP_ID'],
+                    'services.qq.client_secret' => $config['QQ_APP_KEY']
+                ];
+                break;
+            case 'weibo':
+                $serviceConfig = [
+                    'services.weibo.client_id' => $config['SINA_API_KEY'],
+                    'services.weibo.client_secret' => $config['SINA_SECRET']
+                ];
+                break;
+            case 'github':
+                $serviceConfig = [
+                    'services.github.client_id' => $config['GITHUB_CLIENT_ID'],
+                    'services.github.client_secret' => $config['GITHUB_CLIENT_SECRET']
+                ];
+                break;
+        }
+        config($serviceConfig);
         // 记录登录前的url
         $data = [
             'targetUrl' => $_SERVER['HTTP_REFERER']
@@ -43,6 +70,33 @@ class OAuthController extends Controller
             'weibo' => 2,
             'github' => 3
         ];
+
+        $config = Cache::remember('config', 10080, function () {
+            return Config::pluck('value','name');
+        });
+        switch ($service)
+        {
+            case 'qq':
+                $serviceConfig = [
+                    'services.qq.client_id' => $config['QQ_APP_ID'],
+                    'services.qq.client_secret' => $config['QQ_APP_KEY']
+                ];
+                break;
+            case 'weibo':
+                $serviceConfig = [
+                    'services.weibo.client_id' => $config['SINA_API_KEY'],
+                    'services.weibo.client_secret' => $config['SINA_SECRET']
+                ];
+                break;
+            case 'github':
+                $serviceConfig = [
+                    'services.github.client_id' => $config['GITHUB_CLIENT_ID'],
+                    'services.github.client_secret' => $config['GITHUB_CLIENT_SECRET']
+                ];
+                break;
+        }
+        config($serviceConfig);
+
         // 获取用户资料
         $user = Socialite::driver($service)->user();
 


### PR DESCRIPTION
白老，你的第三方登录有BUG啊。
虽然你在AppServiceProvider.php中注册了一个服务，给每个视图都修改了/config/service.php中的第三方登录所需要的id和secret。
但是，在第三方登录的控制器里面。本身是没有渲染到视图的那个步骤就直接调用了laravel提供的第三方登录类，所以这里控制器并没有经过你提供的那个服务，导致第三方登录没法获取id和secret。我简陋的由我的思想写了下修改方案。