### PR TITLE
在直接删除文章后保证标签下没有文章

### DIFF
--- a/app/Http/Controllers/Admin/ArticleController.php
+++ b/app/Http/Controllers/Admin/ArticleController.php
@@ -204,11 +204,18 @@ class ArticleController extends Controller
      *
      * @param         $id
      * @param Article $articleModel
+     * @param ArticleTag $articleTagModel
      *
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function forceDelete($id, Article $articleModel)
+    public function forceDelete($id, Article $articleModel, ArticleTag $articleTagModel)
     {
+        // 先删除此文章下的所有标签
+        $map = [
+            'article_id' => $id
+        ];
+        $articleTagModel->whereMap($map)->forceDelete();
+
         $map = compact('id');
         $articleModel->forceDeleteData($map);
         return redirect('admin/article/index');


### PR DESCRIPTION
很多新人第一次使用时想删除标签发现有文章就会去删除文章。
此时删除文章后并没有删除与标签的关联。
导致标签仍然删除不了。